### PR TITLE
refactor: Do one prediction per input sequence, easier experimentation

### DIFF
--- a/notebooks/generate.ipynb
+++ b/notebooks/generate.ipynb
@@ -8,8 +8,10 @@
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "from autora.doc.runtime.predict_hf import Predictor\n",
-    "from autora.doc.runtime.prompts import PROMPTS, PromptIds"
+    "from autora.doc.runtime.predict_hf import Predictor, preprocess_code\n",
+    "from autora.doc.runtime.prompts import PROMPTS, PromptIds, PromptBuilder, SYS_GUIDES\n",
+    "from autora.doc.pipelines.main import evaluate_documentation\n",
+    "from autora.doc.pipelines.main import eval_prompt, load_data"
    ]
   },
   {
@@ -18,9 +20,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model = \"../../models\" # if model has been previously downloaded via huggingface-cli\n",
-    "model = \"meta-llama/Llama-2-7b-chat-hf\"\n",
+    "model = \"meta-llama/Llama-2-7b-chat-hf\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "pred = Predictor(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test generation for the variable declararion only"
    ]
   },
   {
@@ -33,7 +49,8 @@
     "iv = Variable(name=\"x\", value_range=(0, 2 * np.pi), allowed_values=np.linspace(0, 2 * np.pi, 30))\n",
     "dv = Variable(name=\"y\", type=ValueType.REAL)\n",
     "variables = VariableCollection(independent_variables=[iv], dependent_variables=[dv])\n",
-    "\"\"\""
+    "\"\"\"\n",
+    "LABEL = \"The discovery problem is defined by a single independent variable $x \\in [0, 2 \\pi]$ and dependent variable $y$.\""
    ]
   },
   {
@@ -42,18 +59,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def test(promptid, code):\n",
+    "def test(promptid, code, label):\n",
     "    output = pred.predict(\n",
     "        PROMPTS[promptid],\n",
     "        [code],\n",
     "        do_sample=0,\n",
-    "        max_length=800,\n",
+    "        max_new_tokens=100,\n",
     "        temperature=0.05,\n",
     "        top_k=10,\n",
     "        num_ret_seq=1,\n",
-    "    )[0]\n",
-    "    for i, o in enumerate(output):\n",
-    "        print(f\"{promptid}\\n******* Output {i} ********\\n{o}\\n*************\\n\")"
+    "    )\n",
+    "    bleu, meteor = evaluate_documentation(output, [label])\n",
+    "    for i, o in enumerate(output[0]):\n",
+    "        print(f\"{promptid}\\n******* Output {i} ********. bleu={bleu}, meteor={meteor}\\n{o}\\n*************\\n\")"
    ]
   },
   {
@@ -62,7 +80,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test(PromptIds.AUTORA_VARS_ZEROSHOT, TEST_VAR_CODE)"
+    "# Zero shot test\n",
+    "test(PromptIds.AUTORA_VARS_ZEROSHOT, TEST_VAR_CODE, LABEL)"
    ]
   },
   {
@@ -71,8 +90,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test(PromptIds.AUTORA_VARS_ONESHOT, TEST_VAR_CODE)"
+    "# One shot test\n",
+    "test(PromptIds.AUTORA_VARS_ONESHOT, TEST_VAR_CODE, LABEL)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## One-shot generation for the complete code sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_file = \"../data/autora/data.jsonl\"\n",
+    "inputs, labels = load_data(data_file)\n",
+    "# preprocessing removes comments, import statements and empty lines\n",
+    "inputs = [preprocess_code(i) for i in inputs]\n",
+    "INSTR = \"Generate high-level, one or two paragraph documentation for the following experiment.\"\n",
+    "prompt = PromptBuilder(SYS_GUIDES, INSTR).add_example(f\"{inputs[0]}\", labels[0]).build()\n",
+    "print(prompt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out, bleu, meteor = eval_prompt(data_file, pred, prompt, {\"max_new_tokens\": 800.0})\n",
+    "print(f\"bleu={bleu}, meteor={meteor}\\n{out[0][0]}\\n*************\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,10 +12,10 @@ TEST_HF_MODEL = "hf-internal-testing/tiny-random-FalconForCausalLM"
 
 def test_predict() -> None:
     data = Path(__file__).parent.joinpath("../data/sweetpea/data.jsonl").resolve()
-    outputs = eval(str(data), TEST_HF_MODEL, PromptIds.SWEETP_1, [])
+    outputs, _, _ = eval(str(data), TEST_HF_MODEL, PromptIds.SWEETP_1, [])
     assert len(outputs) == 3, "Expected 3 outputs"
     for output in outputs:
-        assert len(output[0]) > 0, "Expected non-empty output"
+        assert len(output) > 0, "Expected non-empty output"
 
 
 def test_evaluation() -> None:
@@ -24,7 +24,7 @@ def test_evaluation() -> None:
     with jsonlines.open(data) as reader:
         items = [item for item in reader]
         labels = [item["output"] for item in items]
-        predictions = [[item["output"]] for item in items]
+        predictions = [item["output"] for item in items]
 
     bleu, meteor = evaluate_documentation(predictions, labels)
     assert bleu == pytest.approx(1, 0.01), f"BLEU Score is {bleu}"
@@ -34,7 +34,7 @@ def test_evaluation() -> None:
 def test_extra_token_in_prediction() -> None:
     # Test Case bleu score should be less due to brevity penalty and meteor is robust to small mistakes
     labels = ["this is a test"]
-    predictions = [["this is a test extra"]]
+    predictions = ["this is a test extra"]
     bleu, meteor = evaluate_documentation(predictions, labels)
     assert 0.6 <= bleu <= 0.8, f"BLEU Score is {bleu}"
     assert 0.8 <= meteor <= 1, f"METEOR Score is {meteor}"
@@ -43,7 +43,7 @@ def test_extra_token_in_prediction() -> None:
 def test_missing_token_in_prediction() -> None:
     # bleu score is less, meteor is higher
     labels = ["this is a test"]
-    predictions = [["this is a"]]
+    predictions = ["this is a"]
     bleu, meteor = evaluate_documentation(predictions, labels)
     assert 0.4 <= bleu <= 0.6, f"BLEU Score is {bleu}"
     assert 0.6 <= meteor <= 0.8, f"METEOR Score is {meteor}"
@@ -52,7 +52,7 @@ def test_missing_token_in_prediction() -> None:
 def test_completely_different_tokens() -> None:
     # both scores are less, as no common tokens
     labels = ["this is a test"]
-    predictions = [["completely different sentence"]]
+    predictions = ["completely different sentence"]
     bleu, meteor = evaluate_documentation(predictions, labels)
     assert bleu <= 0.1, f"BLEU Score is {bleu}"
     assert meteor <= 0.1, f"METEOR Score is {meteor}"
@@ -61,7 +61,7 @@ def test_completely_different_tokens() -> None:
 def test_partially_matching_tokens() -> None:
     # As ngrams arent matching because of extra token within, BLEU score is very less. Meteor gives a good score only.
     labels = ["this is a test"]
-    predictions = [["this is a different test"]]
+    predictions = ["this is a different test"]
     bleu, meteor = evaluate_documentation(predictions, labels)
     assert 0.25 <= bleu <= 0.4, f"BLEU Score is {bleu}"
     assert 0.8 <= meteor <= 0.95, f"METEOR Score is {meteor}"


### PR DESCRIPTION
The prediction/evaluation interfaces used `List[List[str]]` as the prediction type to account for: a) batch inference, i.e. generate docs for multiple code snippets in one pass and b) generating multiple predictions per input (sampling). But we've now decided to do deterministic prediction (temp=0) so there's no need for the second level. 

This PR changes to the prediction return type to `List[str]`, which also makes the code simpler.

Two additional changes: 
- Replace the use of the `max_length` parameter in favor of `max_new_tokens`
- Break-up the `eval` function into `eval_promp` for easier prompt experimentation
- Updated generate.ipynb notebook accordingly
