### PR TITLE
feat: Publish/load pre-quantized models

### DIFF
--- a/.github/actions/deps/action.yaml
+++ b/.github/actions/deps/action.yaml
@@ -18,4 +18,4 @@ runs:
         python3 -m pip install --upgrade pip
     - name: Install project
       shell: sh
-      run: pip install ".[dev,train]"
+      run: pip install ".[dev,train,cuda]"

--- a/notebooks/generate.ipynb
+++ b/notebooks/generate.ipynb
@@ -25,7 +25,9 @@
     "# Uncomment to clone and install autodoc from GitHub\n",
     "# !pip uninstall -y autora-doc\n",
     "# !git clone https://github.com/AutoResearch/autodoc.git\n",
-    "# !pip install -e \"./autodoc[cuda,train]\""
+    "# !pip install \"./autodoc[cuda,train]\"\n",
+    "\n",
+    "# IMPORTANT: Please restart the runtime after running the above commands"
    ]
   },
   {

--- a/notebooks/generate.ipynb
+++ b/notebooks/generate.ipynb
@@ -25,12 +25,7 @@
     "# Uncomment to clone and install autodoc from GitHub\n",
     "# !pip uninstall -y autora-doc\n",
     "# !git clone https://github.com/AutoResearch/autodoc.git\n",
-    "# !pip install -e \"./autodoc[cuda,train]\"\n",
-    "\n",
-    "# Login to Huggingface since access to the model repo is private\n",
-    "# 1) Request access through: https://ai.meta.com/resources/models-and-libraries/llama-downloads/\n",
-    "# 2) Get a Huggingface token from: https://huggingface.co/settings/token (use same email as above)\n",
-    "# !huggingface-cli login --token <your HF token>"
+    "# !pip install -e \"./autodoc[cuda,train]\""
    ]
   },
   {

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -8,6 +8,7 @@
    "source": [
     "from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer\n",
     "import torch\n",
+    "import huggingface_hub\n",
     "\n",
     "print(torch.cuda.is_available())"
    ]
@@ -55,7 +56,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Running this requires loging into HuggingFace via `huggingface-cli login --token` using a write token\n",
+    "# This will work when running from a Jupyter notebook or Colab.\n",
+    "# For other authentication methods, see https://huggingface.co/docs/huggingface_hub/main/en/quick-start#authentication\n",
+    "huggingface_hub.notebook_login(new_session=False, write_permission=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "tokenizer.push_to_hub(target_model_path)\n",
     "model.push_to_hub(target_model_path)"
    ]
@@ -82,9 +93,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "autodoc",
+   "display_name": ".env",
    "language": "python",
-   "name": "autodoc"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -96,7 +107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -6,12 +6,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from azureml.core import Workspace, Datastore\n",
+    "# from azureml.core import Workspace, Datastore\n",
     "from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer\n",
     "import torch\n",
-    "\n",
+    "print(torch.cuda.is_available())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# model_path = \"codellama/CodeLlama-7b-Instruct-hf\"\n",
-    "model_path = \"meta-llama/Llama-2-7b-chat-hf\""
+    "# model_path = \"meta-llama/Llama-2-7b-chat-hf\"\n",
+    "model_path = \"./models/meta-llama/Llama-2-7b-chat-hf\"\n",
+    "print(model_path)"
    ]
   },
   {
@@ -39,7 +49,7 @@
    "outputs": [],
    "source": [
     "tokenizer = AutoTokenizer.from_pretrained(model_path)\n",
-    "model = AutoModelForCausalLM.from_pretrained(model_path, **conf)"
+    "model = AutoModelForCausalLM.from_pretrained(model_path, device_map=\"auto\")"
    ]
   },
   {
@@ -58,18 +68,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "model.save_pretrained(f\"./models/{model_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# If all goes well, upload to blob storage:\n",
     "workspace = Workspace.from_config()\n",
     "ds = workspace.get_default_datastore()\n",
     "ds.upload(f\"./models/{model_path}\", f\"./base_models/{model_path}\", show_progress=True, overwrite=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.push_to_hub(\"carlosgjs/Llama-2-7b-chat-hf-4bit\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer.push_to_hub(\"carlosgjs/Llama-2-7b-chat-hf-4bit\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".env",
+   "display_name": "autodoc",
    "language": "python",
-   "name": "python3"
+   "name": "autodoc"
   },
   "language_info": {
    "codemirror_mode": {
@@ -81,9 +125,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from azureml.core import Workspace, Datastore\n",
     "from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer\n",
     "import torch\n",
+    "\n",
     "print(torch.cuda.is_available())"
    ]
   },
@@ -21,7 +21,8 @@
     "# model_path = \"codellama/CodeLlama-7b-Instruct-hf\"\n",
     "# model_path = \"meta-llama/Llama-2-7b-chat-hf\"\n",
     "model_path = \"./models/meta-llama/Llama-2-7b-chat-hf\"\n",
-    "print(model_path)"
+    "print(model_path)\n",
+    "target_model_path = \"carlosgjs/Llama-2-7b-chat-hf-4bit\""
    ]
   },
   {
@@ -58,8 +59,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model.save_pretrained(f\"./models/{model_path}\")\n",
-    "tokenizer.save_pretrained(f\"./models/{model_path}\")"
+    "# Running this requires loging into HuggingFace via `huggingface-cli login --token` using a write token\n",
+    "tokenizer.push_to_hub(target_model_path)\n",
+    "model.push_to_hub(target_model_path)"
    ]
   },
   {
@@ -68,52 +70,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.save_pretrained(f\"./models/{model_path}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Alternatvely, upload to Azure Blob Storage\n",
+    "from azureml.core import Workspace\n",
+    "\n",
+    "# save locally first\n",
+    "tokenizer.save_pretrained(f\"./models/{model_path}\")\n",
+    "model.save_pretrained(f\"./models/{model_path}\")\n",
+    "\n",
     "# If all goes well, upload to blob storage:\n",
     "workspace = Workspace.from_config()\n",
     "ds = workspace.get_default_datastore()\n",
-    "ds.upload(f\"./models/{model_path}\", f\"./base_models/{model_path}\", show_progress=True, overwrite=True)"
+    "ds.upload(\n",
+    "    f\"./models/{target_model_path}\", f\"./base_models/{target_model_path}\", show_progress=True, overwrite=True\n",
+    ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.push_to_hub(\"carlosgjs/Llama-2-7b-chat-hf-4bit\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tokenizer.push_to_hub(\"carlosgjs/Llama-2-7b-chat-hf-4bit\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "autodoc",
+   "display_name": ".env",
    "language": "python",
-   "name": "autodoc"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -125,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -76,9 +76,7 @@
     "# If all goes well, upload to blob storage:\n",
     "workspace = Workspace.from_config()\n",
     "ds = workspace.get_default_datastore()\n",
-    "ds.upload(\n",
-    "    f\"./models/{model_path}\", f\"./base_models/{target_model_path}\", show_progress=True, overwrite=True\n",
-    ")"
+    "ds.upload(f\"./models/{model_path}\", f\"./base_models/{target_model_path}\", show_progress=True, overwrite=True)"
    ]
   }
  ],

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -18,17 +18,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_path = \"./models/meta-llama/Llama-2-7b-chat-hf\"\n",
+    "model_path = \"meta-llama/Llama-2-7b-chat-hf\"\n",
     "print(model_path)\n",
     "target_model_path = \"autora-doc/Llama-2-7b-chat-hf-nf4\""
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -84,16 +77,16 @@
     "workspace = Workspace.from_config()\n",
     "ds = workspace.get_default_datastore()\n",
     "ds.upload(\n",
-    "    f\"./models/{target_model_path}\", f\"./base_models/{target_model_path}\", show_progress=True, overwrite=True\n",
+    "    f\"./models/{model_path}\", f\"./base_models/{target_model_path}\", show_progress=True, overwrite=True\n",
     ")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".env",
+   "display_name": "autodoc",
    "language": "python",
-   "name": "python3"
+   "name": "autodoc"
   },
   "language_info": {
    "codemirror_mode": {
@@ -105,7 +98,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -18,12 +18,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model_path = \"codellama/CodeLlama-7b-Instruct-hf\"\n",
-    "# model_path = \"meta-llama/Llama-2-7b-chat-hf\"\n",
     "model_path = \"./models/meta-llama/Llama-2-7b-chat-hf\"\n",
     "print(model_path)\n",
-    "target_model_path = \"carlosgjs/Llama-2-7b-chat-hf-4bit\""
+    "target_model_path = \"autora-doc/Llama-2-7b-chat-hf-nf4\""
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -32,15 +37,12 @@
    "outputs": [],
    "source": [
     "# Load the model in 4bit quantization for faster inference on smaller GPUs\n",
-    "conf = {\n",
-    "    \"quantization_config\": BitsAndBytesConfig(\n",
-    "        load_in_4bit=True,\n",
-    "        bnb_4bit_use_double_quant=True,\n",
-    "        bnb_4bit_quant_type=\"nf4\",\n",
-    "        bnb_4bit_compute_dtype=torch.bfloat16,\n",
-    "    ),\n",
-    "    \"device_map\": \"auto\",\n",
-    "}"
+    "conf = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True,\n",
+    "    bnb_4bit_use_double_quant=True,\n",
+    "    bnb_4bit_quant_type=\"nf4\",\n",
+    "    bnb_4bit_compute_dtype=torch.bfloat16,\n",
+    ")"
    ]
   },
   {
@@ -49,8 +51,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Load the tokenizer and model\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_path)\n",
-    "model = AutoModelForCausalLM.from_pretrained(model_path, device_map=\"auto\")"
+    "model = AutoModelForCausalLM.from_pretrained(model_path, quantization_config=conf, device_map=\"auto\")"
    ]
   },
   {
@@ -70,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Alternatvely, upload to Azure Blob Storage\n",
+    "# Alternatvely, upload to Azure Blob Storage (currently not used)\n",
     "from azureml.core import Workspace\n",
     "\n",
     "# save locally first\n",

--- a/notebooks/import_model.ipynb
+++ b/notebooks/import_model.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core import Workspace, Datastore\n",
+    "from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer\n",
+    "import torch\n",
+    "\n",
+    "# model_path = \"codellama/CodeLlama-7b-Instruct-hf\"\n",
+    "model_path = \"meta-llama/Llama-2-7b-chat-hf\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the model in 4bit quantization for faster inference on smaller GPUs\n",
+    "conf = {\n",
+    "    \"quantization_config\": BitsAndBytesConfig(\n",
+    "        load_in_4bit=True,\n",
+    "        bnb_4bit_use_double_quant=True,\n",
+    "        bnb_4bit_quant_type=\"nf4\",\n",
+    "        bnb_4bit_compute_dtype=torch.bfloat16,\n",
+    "    ),\n",
+    "    \"device_map\": \"auto\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(model_path)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_path, **conf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# model.save_pretrained(f\"./models/{model_path}\")\n",
+    "tokenizer.save_pretrained(f\"./models/{model_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If all goes well, upload to blob storage:\n",
+    "workspace = Workspace.from_config()\n",
+    "ds = workspace.get_default_datastore()\n",
+    "ds.upload(f\"./models/{model_path}\", f\"./base_models/{model_path}\", show_progress=True, overwrite=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [project]
 name = "autora-doc"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 readme = "README.md"
-authors = [
-    { name = "Carlos Garcia Jurado Suarez", email = "carlosg@uw.edu" }
-]
+authors = [{ name = "Carlos Garcia Jurado Suarez", email = "carlosg@uw.edu" }]
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -29,36 +27,26 @@ description = "Automatic documentation generator from AutoRA code"
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-cov", # Used to report total code coverage
-    "pre-commit", # Used to run checks before finalizing a git commit
-    "sphinx", # Used to automatically generate documentation
+    "pytest-cov",       # Used to report total code coverage
+    "pre-commit",       # Used to run checks before finalizing a git commit
+    "sphinx",           # Used to automatically generate documentation
     "sphinx-rtd-theme", # Used to render documentation
-    "sphinx-autoapi", # Used to automatically generate api documentation
-    "black", # Used for static linting of files
-    "mypy", # Used for static type checking of files
+    "sphinx-autoapi",   # Used to automatically generate api documentation
+    "black",            # Used for static linting of files
+    "mypy",             # Used for static type checking of files
     # if you add dependencies here while experimenting in a notebook and you
     # want that notebook to render in your documentation, please add the
     # dependencies to ./docs/requirements.txt as well.
-    "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
-    "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
-    "ipython", # Also used in building notebooks into Sphinx
-    "matplotlib", # Used in sample notebook intro_notebook.ipynb
+    "nbconvert",   # Needed for pre-commit check to clear output from Python notebooks
+    "nbsphinx",    # Used to integrate Python notebooks into Sphinx documentation
+    "ipython",     # Also used in building notebooks into Sphinx
+    "matplotlib",  # Used in sample notebook intro_notebook.ipynb
     "ipykernel",
     "hf_transfer",
 ]
-train = [
-    "jsonlines",
-    "mlflow",
-]
-azure = [
-    "azureml-core",
-    "azureml-mlflow",
-]
-cuda = [
-    "bitsandbytes>=0.42.0",
-    "accelerate>=0.24.1",
-    "xformers",
-]
+train = ["jsonlines", "mlflow"]
+azure = ["azureml-core", "azureml-mlflow"]
+cuda = ["bitsandbytes>=0.42.0", "accelerate>=0.24.1", "xformers"]
 
 [project.urls]
 Homepage = "https://github.com/AutoResearch/autodoc"
@@ -68,9 +56,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 
 [tool.black]
 line-length = 110
@@ -81,7 +67,7 @@ profile = "black"
 line_length = 110
 
 [tool.coverage.run]
-omit=["src/autora/doc/_version.py"]
+omit = ["src/autora/doc/_version.py"]
 
 [tool.hatch]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy",
     # This works, while installing from pytorch and cuda from conda does not",
     "torch==2.0.1",
-    "transformers>=4.35.2",
+    "transformers>=4.37.2",
     "nltk",
 ]
 
@@ -55,7 +55,7 @@ azure = [
     "azureml-mlflow",
 ]
 cuda = [
-    "bitsandbytes>=0.41.2.post2",
+    "bitsandbytes>=0.42.0",
     "accelerate>=0.24.1",
     "xformers",
 ]

--- a/src/autora/doc/pipelines/main.py
+++ b/src/autora/doc/pipelines/main.py
@@ -187,7 +187,7 @@ def generate(
     predictions = pred.predict(prompt, [input], **param_dict)
     assert len(predictions) == 1, f"Expected only one output, got {len(predictions)}"
     logger.info(f"Writing output to {output}")
-    with open(output, "w") as f:
+    with open(output, "w", encoding="utf-8") as f:
         f.write(predictions[0])
 
 

--- a/src/autora/doc/runtime/predict_hf.py
+++ b/src/autora/doc/runtime/predict_hf.py
@@ -25,7 +25,7 @@ def preprocess_code(code: str) -> str:
 
 class Predictor:
     def __init__(self, input_model_path: str):
-        model_path, config = self.get_config(input_model_path)
+        model_path, config = Predictor.get_config(input_model_path)
         if model_path != input_model_path:
             logger.info(f"Mapped requested model '{input_model_path}' to '{model_path}'")
 
@@ -89,7 +89,8 @@ class Predictor:
         tokens: Dict[str, List[List[int]]] = self.tokenizer(input)
         return tokens
 
-    def get_config(self, model_path: str) -> Tuple[str, Dict[str, str]]:
+    @staticmethod
+    def get_config(model_path: str) -> Tuple[str, Dict[str, str]]:
         if torch.cuda.is_available():
             from transformers import BitsAndBytesConfig
 
@@ -100,12 +101,12 @@ class Predictor:
                 return mapped_path, config
 
             # Load the model in 4bit quantization for faster inference on smaller GPUs
-            config ["quantization_config"] = BitsAndBytesConfig(
-                    load_in_4bit=True,
-                    bnb_4bit_use_double_quant=True,
-                    bnb_4bit_quant_type="nf4",
-                    bnb_4bit_compute_dtype=torch.bfloat16,
-                )
+            config["quantization_config"] = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+            )
             return model_path, config
         else:
             return model_path, {}

--- a/src/autora/doc/runtime/predict_hf.py
+++ b/src/autora/doc/runtime/predict_hf.py
@@ -93,17 +93,19 @@ class Predictor:
         if torch.cuda.is_available():
             from transformers import BitsAndBytesConfig
 
-            model_path = quantized_models.get(model_path, model_path)
+            config = {"device_map": "auto"}
+            mapped_path = quantized_models.get(model_path, None)
+            if mapped_path:
+                # found an already quantized model, so no need to get a new quant config
+                return mapped_path, config
 
             # Load the model in 4bit quantization for faster inference on smaller GPUs
-            return model_path, {
-                "quantization_config": BitsAndBytesConfig(
+            config ["quantization_config"] = BitsAndBytesConfig(
                     load_in_4bit=True,
                     bnb_4bit_use_double_quant=True,
                     bnb_4bit_quant_type="nf4",
                     bnb_4bit_compute_dtype=torch.bfloat16,
-                ),
-                "device_map": "auto",
-            }
+                )
+            return model_path, config
         else:
             return model_path, {}

--- a/src/autora/doc/runtime/predict_hf.py
+++ b/src/autora/doc/runtime/predict_hf.py
@@ -9,8 +9,7 @@ from autora.doc.runtime.prompts import CODE_PLACEHOLDER, LLAMA2_INST_CLOSE
 
 logger = logging.getLogger(__name__)
 
-# TODO: Redirect the quantized model to an 'autora' HF org
-quantized_models = {"meta-llama/Llama-2-7b-chat-hf": "carlosgjs/Llama-2-7b-chat-hf-4bit"}
+quantized_models = {"meta-llama/Llama-2-7b-chat-hf": "autora-doc/Llama-2-7b-chat-hf-nf4"}
 
 
 def preprocess_code(code: str) -> str:

--- a/tests/test_predict_hf.py
+++ b/tests/test_predict_hf.py
@@ -1,4 +1,10 @@
-from autora.doc.runtime.predict_hf import Predictor
+from unittest import mock
+
+from autora.doc.runtime.predict_hf import Predictor, quantized_models
+
+# Test models with and without available quantized models
+MODEL_NO_QUANTIZED = "hf-internal-testing/tiny-random-FalconForCausalLM"
+MODEL_WITH_QUANTIZED = "meta-llama/Llama-2-7b-chat-hf"
 
 
 def test_trim_prompt() -> None:
@@ -14,3 +20,22 @@ output
 """
     output = Predictor.trim_prompt(with_marker)
     assert output == "output\n"
+
+
+@mock.patch("torch.cuda.is_available", return_value=True)
+def test_get_config_cuda(mock: mock.Mock) -> None:
+    model, config = Predictor.get_config(MODEL_WITH_QUANTIZED)
+    assert model == quantized_models[MODEL_WITH_QUANTIZED]
+    assert "quantization_config" not in config
+
+    model, config = Predictor.get_config(MODEL_NO_QUANTIZED)
+    # no pre-quantized model available
+    assert model == MODEL_NO_QUANTIZED
+    assert "quantization_config" in config
+
+
+@mock.patch("torch.cuda.is_available", return_value=False)
+def test_get_config_nocuda(mock: mock.Mock) -> None:
+    model, config = Predictor.get_config(MODEL_WITH_QUANTIZED)
+    assert model == MODEL_WITH_QUANTIZED
+    assert len(config) == 0


### PR DESCRIPTION
Running quantized models significantly reduces the GPU memory required for inference. Instead of downloading the full model and quantizing it during the load, we can quantize the model offline and save it. At runtime the (smaller) quantized model can be loaded.

This PR includes 3 changes:
- Updates to the `bitsandbytes` and `transformers` versions which support quantizing
- A notebook for quantizing and publishing models
- Logic to map known models to their pre-quantized versions.

Closes #4 
Closes #8 
