### PR TITLE
fix: Bound numpy version to avoid incompatibilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pipelines = [
     "nltk",
     "sentence-transformers>=2.3.1",
     "peft>=0.8.2",
-    "trl>=0.7.10",
+    "trl==0.7.10",
     "datasets",
     "tensorboardX",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy",
     # This works, while installing from pytorch and cuda from conda does not",
     "torch==2.0.1",
-    "transformers>=4.37.2",
+    "transformers==4.37.2",
     "numpy<2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     # This works, while installing from pytorch and cuda from conda does not",
     "torch==2.0.1",
     "transformers>=4.37.2",
+    "numpy<2.0",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)


### PR DESCRIPTION
## Change Description
Numpy 2.0 has been released, which is incompatible with the transformer libraries used in this project


## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
